### PR TITLE
chore: change to npm

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,13 +25,13 @@
       "automerge": false
     },
     {
-      "matchManagers": ["pnpm"],
+      "matchManagers": ["npm"],
       "matchDatasources": ["npm"],
       "matchUpdateTypes": ["digest", "pin", "patch", "minor"],
       "automerge": true
     },
     {
-      "matchManagers": ["pnpm"],
+      "matchManagers": ["npm"],
       "matchDatasources": ["npm"],
       "matchUpdateTypes": ["major"],
       "automerge": false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Atualizada a configuração do Renovate para aplicar regras de automerge a pacotes gerenciados pelo npm, em vez do pnpm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->