### PR TITLE
Add CI workflows for build, lint and security

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  build-go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Build API
+        run: go build ./server/cmd/api
+
+  build-app:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v3
+        with:
+          version: latest
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: app
+      - name: Build PWA
+        run: pnpm run build
+        working-directory: app

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,38 @@
+name: Lint
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  golang:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.3.0
+          only-new-issues: true
+          args: ./...
+
+  pwa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v3
+        with:
+          version: latest
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: app
+      - name: Type check
+        run: pnpm exec tsc --noEmit
+        working-directory: app

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,37 @@
+name: Security
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        run: govulncheck ./...
+
+  npm-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v3
+        with:
+          version: latest
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: app
+      - name: Audit dependencies
+        run: pnpm audit --audit-level=high
+        working-directory: app

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ install-go-lint:
 	@if ! command golangci-lint -v > /dev/null; then \
 		read -p "Go's linter is not installed on your machine. Do you want to install it? [Y/n] " choice; \
 		if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
-			curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.6; \
+                        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.3.0; \
 			if [ ! -x "$$(command golangci-lint -v)" ]; then \
 				echo "Go linter installation failed. Exiting..."; \
 				exit 1; \


### PR DESCRIPTION
## Summary
- add GitHub Actions to build the Go API and PWA
- lint the codebase using golangci-lint and TypeScript
- check dependencies for vulnerabilities using govulncheck and pnpm audit
- update golangci-lint version and configure the action to show only new issues

## Testing
- `pnpm --dir app run build`
- `go build ./server/cmd/api`
- `golangci-lint run ./...`
- `pnpm --dir app exec tsc --noEmit`
- `pnpm --dir app audit --audit-level=high`
- `govulncheck ./...` *(failed: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6886fafbaea88322b420a14d7fc7cb10