### PR TITLE
Add AGENT guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Guidelines for FinAssisty
+
+These instructions apply to all files **outside of `app/`**. The main backend is written in Go.
+
+## Go code style
+- Format all Go code using `gofmt` before committing.
+- Organize imports in three groups: standard library, third-party, and local packages.
+- Follow `golangci-lint` rules defined in `.golangci.yml` by running `golangci-lint run ./...`.
+- Run `go test ./...` to ensure tests pass.
+- After adding dependencies run `go mod tidy` so `go.mod` and `go.sum` stay in sync.
+- Keep environment examples in `.env.example` up to date.
+
+## Documentation
+- When editing files in `docs/architecture/`, regenerate PNG diagrams with `make docs`.
+
+## Pull Requests
+- Use commit messages in the form `feat:`, `fix:` or similar prefixes.
+- Provide a short summary of changes and mention test results or why tests could not be run.

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -1,0 +1,14 @@
+# Frontend Guidelines
+
+These rules apply to everything inside the `app/` folder (React + TypeScript PWA).
+
+## Code style
+- Follow the project `.editorconfig` for indentation (4 spaces for `.ts`/`.tsx`).
+- Use functional React components and hooks.
+- Keep imports using the `@/` alias for paths under `src/` when possible.
+- Run `pnpm exec eslint src --ext ts,tsx` to lint the code.
+- Run `pnpm exec tsc --noEmit` to check TypeScript types.
+- Keep `pnpm-lock.yaml` in sync when dependencies change.
+
+## Pull Requests
+- Summarize frontend changes and include lint/type-check results in the PR description.


### PR DESCRIPTION
## Summary
- add `AGENTS.md` at repo root describing Go backend guidelines
- add `AGENTS.md` in `app/` describing React + TypeScript guidelines

## Testing
- `go test ./...`
- `pnpm --dir app exec tsc --noEmit`
- `pnpm --dir app exec eslint src --ext ts,tsx`

------
https://chatgpt.com/codex/tasks/task_e_6887ae266b2c8322afe3ff9bfcf8762d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentação**
  * Adicionados novos guias de contribuição para desenvolvimento backend e frontend, incluindo padrões de código, organização de imports, uso de ferramentas de lint e testes, atualização de dependências e orientações para pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->